### PR TITLE
Fix Error When Adding Outfits and Rig is Hidden

### DIFF
--- a/rr_avatar_tools/utils.py
+++ b/rr_avatar_tools/utils.py
@@ -97,7 +97,7 @@ def put_file_in_known_good_state(func):
 
     def wrapper(*args, **kwargs):
         # Ensure object mode
-        mode = bpy.context.object.mode if bpy.context.object else None
+        mode = bpy.context.object.mode if bpy.context.active_object else None
         if mode:
             bpy.ops.object.mode_set(mode="OBJECT")
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3463596b-3af1-4c04-ad9a-0edd60655f27)

# Summary
When attempting to add outfits when the rig is hidden the above error is thrown. This is from an incorrect check in `put_file_in_known_good_state()`. This fix corrects that check.