### PR TITLE
Fix: Ensure all faces are visible during n-gon fixing operation

### DIFF
--- a/rr_avatar_tools/operators/diagnostics.py
+++ b/rr_avatar_tools/operators/diagnostics.py
@@ -396,7 +396,8 @@ class RR_OT_DiagnosticsFixNgons(RecRoomDiagnosticOperator):
             mesh.hide_set(False)
 
             bpy.ops.object.mode_set(mode="EDIT")
-
+            # Reveal any potentially hiding faces
+            bpy.ops.mesh.reveal()
             # Select ngons and fix
             bpy.ops.mesh.select_all(action="DESELECT")
             bpy.ops.mesh.select_face_by_sides(type="GREATER")


### PR DESCRIPTION
Added `bpy.ops.mesh.reveal()` operator call to ensure the mesh is completely visible in edit mode just before performing the fix to n-gons.

_Noticed this didn't work if you were working on a mesh that had faces still hidden in edit mode._

