### PR TITLE
Fix: Updated utils.py for Diagnostics failing to fix unapplied transforms if the mesh somehow has animation data

### DIFF
--- a/rr_avatar_tools/utils.py
+++ b/rr_avatar_tools/utils.py
@@ -101,6 +101,12 @@ def put_file_in_known_good_state(func):
         if mode and mode != "OBJECT":
             bpy.ops.object.mode_set(mode="OBJECT")
 
+        # Checks and Remove all animation data from Object
+        obj = bpy.context.active_object if bpy.context.active_object else None
+        if obj and obj.animation_data and any([obj.animation_data.action, obj.animation_data.drivers, obj.animation_data.nla_tracks]):
+            obj.animation_data_clear()
+        
+
         # Cache current state
         active = bpy.context.active_object
         collections = [CollectionState(c) for c in rr_avatar_tools.data.collections]


### PR DESCRIPTION
Added a check to see if the active object has any animation data and clears if so.

This fixes an issue where Fixing Unapplied Transforms would seem to work until the user plays the animation timeline, causing the mesh to have unapplied transforms once again.

